### PR TITLE
Transform Active Points option for the Reshape Tool

### DIFF
--- a/sources/pointdragtool.cpp
+++ b/sources/pointdragtool.cpp
@@ -749,3 +749,618 @@ void TranslateHandleDragTool::draw(const QPointF& onePixelLength) {
     glLineWidth(1);
   }
 }
+
+//--------------------------------------------------------
+//--------------------------------------------------------
+
+ActivePointsDragTool::ActivePointsDragTool(TransformHandleId handleId,
+                                           const QSet<int>& points,
+                                           const QRectF& handleRect)
+    : m_handleId(handleId), m_handleRect(handleRect) {
+  m_project = IwApp::instance()->getCurrentProject()->getProject();
+  m_layer   = IwApp::instance()->getCurrentLayer()->getLayer();
+  // 関わるシェイプをリストに格納する
+  QSet<int>::const_iterator i = points.constBegin();
+  while (i != points.constEnd()) {
+    int name       = *i;
+    OneShape shape = m_layer->getShapePairFromName(name);
+
+    int pointIndex = (int)((name % 10000) / 10);
+
+    // 新たなシェイプの場合、追加
+    if (!m_shapes.contains(shape)) {
+      m_shapes.append(shape);
+      QList<int> list;
+      list << pointIndex;
+      m_pointsInShapes.append(list);
+    } else {
+      m_pointsInShapes[m_shapes.indexOf(shape)].append(pointIndex);
+    }
+    ++i;
+  }
+
+  // 現在のフレームを得る
+  int frame = m_project->getViewFrame();
+
+  // 元の形状と、キーフレームだったかどうかを取得する
+  for (int s = 0; s < m_shapes.count(); s++) {
+    OneShape shape = m_shapes.at(s);
+    // キーフレームだったかどうか
+    m_wasKeyFrame.push_back(shape.shapePairP->isFormKey(frame, shape.fromTo));
+    // m_wasKeyFrame.push_back(m_shapes.at(s)->isFormKey(frame));
+
+    // 元の形状の登録
+    m_orgPoints.append(
+        shape.shapePairP->getBezierPointList(frame, shape.fromTo));
+  }
+}
+
+//--------------------------------------------------------
+// つかんだハンドルの反対側のハンドル位置を返す
+//--------------------------------------------------------
+QPointF ActivePointsDragTool::getOppositeHandlePos() {
+  QRectF box = m_handleRect;
+
+  // 基準の点を返す
+  switch (m_handleId) {
+  case Handle_BottomRight:
+    return box.topLeft();
+    break;
+  case Handle_Right:
+  case Handle_RightEdge:
+    return QPointF(box.left(), box.center().y());
+    break;
+  case Handle_TopRight:
+    return box.bottomLeft();
+    break;
+  case Handle_Top:
+  case Handle_TopEdge:
+    return QPointF(box.center().x(), box.bottom());
+    break;
+  case Handle_TopLeft:
+    return box.bottomRight();
+    break;
+  case Handle_Left:
+  case Handle_LeftEdge:
+    return QPointF(box.right(), box.center().y());
+    break;
+  case Handle_BottomLeft:
+    return box.topRight();
+    break;
+  case Handle_Bottom:
+  case Handle_BottomEdge:
+    return QPointF(box.center().x(), box.top());
+    break;
+  default:
+    break;
+  }
+  // 保険
+  return box.center();
+}
+
+//--------------------------------------------------------
+
+bool ActivePointsDragTool::onRelease(const QPointF&, const QMouseEvent*) {
+  QList<BezierPointList> afterPoints;
+  // 現在のフレームを得る
+  int frame = m_project->getViewFrame();
+
+  // 変形後のシェイプを取得
+  for (int s = 0; s < m_orgPoints.count(); s++) {
+    // シェイプを取得
+    OneShape shape = m_shapes.at(s);
+    BezierPointList afterFormKey =
+        shape.shapePairP->getBezierPointList(frame, shape.fromTo);
+
+    afterPoints.push_back(afterFormKey);
+  }
+
+  // Undoに登録 同時にredoが呼ばれるが、最初はフラグで回避する
+  IwUndoManager::instance()->push(new ActivePointsDragToolUndo(
+      m_shapes, m_orgPoints, afterPoints, m_wasKeyFrame, m_project, frame));
+
+  IwApp::instance()->getCurrentProject()->notifyProjectChanged();
+  // 変更されるフレームをinvalidate
+  for (auto shape : m_shapes) {
+    int start, end;
+    shape.shapePairP->getFormKeyRange(start, end, frame, shape.fromTo);
+    IwTriangleCache::instance()->invalidateCache(
+        start, end, m_project->getParentShape(shape.shapePairP));
+  }
+  return true;
+}
+
+//--------------------------------------------------------
+//--------------------------------------------------------
+// ハンドルCtrlクリック   → 回転モード (＋Shiftで45度ずつ)
+//--------------------------------------------------------
+
+ActivePointsRotateDragTool::ActivePointsRotateDragTool(
+    TransformHandleId handleId, const QSet<int>& points,
+    const QRectF& handleRect, const QPointF& onePix)
+    : ActivePointsDragTool(handleId, points, handleRect)
+    , m_onePixLength(onePix) {}
+
+//--------------------------------------------------------
+
+void ActivePointsRotateDragTool::onClick(const QPointF& pos,
+                                         const QMouseEvent* /*e*/) {
+  // 最初の角度を得る
+  // if (m_tool->IsRotateAroundCenter())
+  m_centerPos = getCenterPos();
+  // else
+  //   m_anchorPos = getOppositeHandlePos();
+  QPointF initVec = pos - m_centerPos;
+
+  m_initialAngle = atan2(initVec.x(), initVec.y());
+}
+
+//--------------------------------------------------------
+
+void ActivePointsRotateDragTool::onDrag(const QPointF& pos,
+                                        const QMouseEvent* e) {
+  // 新たな回転角
+  QPointF newVec = pos - m_centerPos;
+
+  double rotAngle = atan2(newVec.x(), newVec.y()) - m_initialAngle;
+
+  double rotDegree = rotAngle * 180.0 / M_PI;
+
+  // Shiftが押されていたら、45度ずつ回転
+  if (e->modifiers() & Qt::ShiftModifier) {
+    while (rotDegree < 0) rotDegree += 360.0;
+
+    int pizzaIndex = (int)(rotDegree / 45.0);
+
+    double amari = rotDegree - (double)pizzaIndex * 45.0;
+
+    if (amari > 22.5f) pizzaIndex += 1;
+
+    rotDegree = (double)pizzaIndex * 45.0;
+  }
+
+  // 現在のフレームを得る
+  int frame = m_project->getViewFrame();
+  // 各シェイプに変形を適用
+  for (int s = 0; s < m_orgPoints.size(); s++) {
+    // シェイプを得る
+    OneShape shape = m_shapes.at(s);
+    // IwShape* shape = m_shapes.at(s);
+    BezierPointList formKey = m_orgPoints.at(s);
+
+    // 回転に合わせて変形を適用していく
+    QTransform affine;
+    affine = affine.translate(m_centerPos.x(), m_centerPos.y());
+    affine = affine.scale(m_onePixLength.x(), m_onePixLength.y());
+    affine = affine.rotate(-rotDegree);
+    affine = affine.scale(1.0 / m_onePixLength.x(), 1.0 / m_onePixLength.y());
+    affine = affine.translate(-m_centerPos.x(), -m_centerPos.y());
+    // 変形
+    for (auto bp : m_pointsInShapes[s]) {
+      // for (int bp = 0; bp < formKey.count(); bp++) {
+      formKey[bp].pos          = affine.map(formKey.at(bp).pos);
+      formKey[bp].firstHandle  = affine.map(formKey.at(bp).firstHandle);
+      formKey[bp].secondHandle = affine.map(formKey.at(bp).secondHandle);
+    }
+
+    // キーを格納
+    shape.shapePairP->setFormKey(frame, shape.fromTo, formKey);
+  }
+}
+
+//--------------------------------------------------------
+//--------------------------------------------------------
+// 縦横ハンドルAltクリック　  → Shear変形モード（＋Shiftで平行に変形）
+//--------------------------------------------------------
+
+ActivePointsShearDragTool::ActivePointsShearDragTool(TransformHandleId handleId,
+                                                     const QSet<int>& points,
+                                                     const QRectF& handleRect)
+    : ActivePointsDragTool(handleId, points, handleRect) {}
+
+//--------------------------------------------------------
+
+void ActivePointsShearDragTool::onClick(const QPointF& pos,
+                                        const QMouseEvent*) {
+  m_startPos = pos;
+
+  m_anchorPos = getOppositeHandlePos();
+
+  // 変形のフラグを得る
+  // 左右のハンドルをクリック：横に拡大縮小、縦にシアー変形
+  // 上下のハンドルをクリック：縦に拡大縮小、横にシアー変形
+  if (m_handleId == Handle_Right || m_handleId == Handle_Left)
+    m_isVertical = true;
+  else
+    m_isVertical = false;
+
+  if (m_handleId == Handle_Left || m_handleId == Handle_Top)
+    m_isInv = true;
+  else
+    m_isInv = false;
+}
+
+//--------------------------------------------------------
+
+void ActivePointsShearDragTool::onDrag(const QPointF& pos,
+                                       const QMouseEvent* e) {
+  int frame = m_project->getViewFrame();
+  // 各シェイプに変形を適用
+  for (int s = 0; s < m_orgPoints.size(); s++) {
+    // シェイプを得る
+    OneShape shape = m_shapes.at(s);
+
+    BezierPointList formKey = m_orgPoints.at(s);
+
+    QTransform affine;
+
+    QPointF scale(1.0, 1.0);
+    if (!(e->modifiers() & Qt::ShiftModifier)) {
+      if (m_isVertical)
+        scale.setX((pos.x() - m_anchorPos.x()) /
+                   (m_startPos.x() - m_anchorPos.x()));
+      else
+        scale.setY((pos.y() - m_anchorPos.y()) /
+                   (m_startPos.y() - m_anchorPos.y()));
+    }
+
+    // シアー位置
+    QPointF shear(0.0, 0.0);
+    if (m_isVertical) {
+      shear.setY(pos.y() - m_startPos.y());
+      shear.setY(shear.y() / (pos.x() - m_anchorPos.x()));
+    } else {
+      shear.setX(pos.x() - m_startPos.x());
+      shear.setX(shear.x() / (pos.y() - m_anchorPos.y()));
+    }
+
+    affine = affine.translate(m_anchorPos.x(), m_anchorPos.y());
+    affine = affine.shear(shear.x(), shear.y());
+    affine = affine.scale(scale.x(), scale.y());
+    affine = affine.translate(-m_anchorPos.x(), -m_anchorPos.y());
+
+    // 変形
+    for (auto bp : m_pointsInShapes[s]) {
+      // for (int bp = 0; bp < formKey.count(); bp++) {
+      formKey[bp].pos          = affine.map(formKey.at(bp).pos);
+      formKey[bp].firstHandle  = affine.map(formKey.at(bp).firstHandle);
+      formKey[bp].secondHandle = affine.map(formKey.at(bp).secondHandle);
+    }
+
+    // キーを格納
+    shape.shapePairP->setFormKey(frame, shape.fromTo, formKey);
+  }
+}
+
+//--------------------------------------------------------
+//--------------------------------------------------------
+// 斜めハンドルAltクリック　  → 台形変形モード（＋Shiftで対称変形）
+//--------------------------------------------------------
+
+ActivePointsTrapezoidDragTool::ActivePointsTrapezoidDragTool(
+    TransformHandleId handleId, const QSet<int>& points,
+    const QRectF& handleRect)
+    : ActivePointsDragTool(handleId, points, handleRect) {}
+
+//--------------------------------------------------------
+
+void ActivePointsTrapezoidDragTool::onClick(const QPointF& pos,
+                                            const QMouseEvent*) {
+  m_startPos = pos;
+
+  // 台形変形の基準となるバウンディングボックスを格納
+  m_initialBox = m_handleRect;
+}
+
+//--------------------------------------------------------
+
+void ActivePointsTrapezoidDragTool::onDrag(const QPointF& pos,
+                                           const QMouseEvent* e) {
+  // 各頂点の変移ベクトルを用意
+  QPointF bottomRightVec(0.0, 0.0);
+  QPointF topRightVec(0.0, 0.0);
+  QPointF topLeftVec(0.0, 0.0);
+  QPointF bottomLeftVec(0.0, 0.0);
+
+  bool isShiftPressed = (e->modifiers() & Qt::ShiftModifier);
+  // ハンドルに合わせて変移ベクトルを移動
+  switch (m_handleId) {
+  case Handle_BottomRight:
+    bottomRightVec = pos - m_startPos;
+    if (isShiftPressed)
+      bottomLeftVec = QPointF(-bottomRightVec.x(), bottomRightVec.y());
+    break;
+  case Handle_TopRight:
+    topRightVec = pos - m_startPos;
+    if (isShiftPressed)
+      bottomRightVec = QPointF(topRightVec.x(), -topRightVec.y());
+    break;
+  case Handle_TopLeft:
+    topLeftVec = pos - m_startPos;
+    if (isShiftPressed) topRightVec = QPointF(-topLeftVec.x(), topLeftVec.y());
+    break;
+  case Handle_BottomLeft:
+    bottomLeftVec = pos - m_startPos;
+    if (isShiftPressed)
+      topLeftVec = QPointF(bottomLeftVec.x(), -bottomLeftVec.y());
+    break;
+  default:
+    break;
+  }
+
+  // 各シェイプの各ポイントについて、４つの変移ベクトルの線形補間を足すことで移動させる
+
+  int frame = m_project->getViewFrame();
+  // 各シェイプに変形を適用
+  for (int s = 0; s < m_orgPoints.count(); s++) {
+    // シェイプを得る
+    OneShape shape = m_shapes.at(s);
+    // IwShape* shape = m_shapes.at(s);
+    BezierPointList formKey = m_orgPoints.at(s);
+
+    // 変形の基準バウンディングボックス
+    QRectF tmpBBox = m_initialBox;
+    // 変形
+    for (auto bp : m_pointsInShapes[s]) {
+      // for (int bp = 0; bp < formKey.count(); bp++) {
+
+      formKey[bp].pos = map(tmpBBox, bottomRightVec, topRightVec, topLeftVec,
+                            bottomLeftVec, formKey[bp].pos);
+      formKey[bp].firstHandle =
+          map(tmpBBox, bottomRightVec, topRightVec, topLeftVec, bottomLeftVec,
+              formKey[bp].firstHandle);
+      formKey[bp].secondHandle =
+          map(tmpBBox, bottomRightVec, topRightVec, topLeftVec, bottomLeftVec,
+              formKey[bp].secondHandle);
+    }
+
+    // キーを格納
+    shape.shapePairP->setFormKey(frame, shape.fromTo, formKey);
+  }
+}
+
+//--------------------------------------------------------
+// ４つの変移ベクトルの線形補間を足すことで移動させる
+//--------------------------------------------------------
+
+QPointF ActivePointsTrapezoidDragTool::map(const QRectF& bBox,
+                                           const QPointF& bottomRightVec,
+                                           const QPointF& topRightVec,
+                                           const QPointF& topLeftVec,
+                                           const QPointF& bottomLeftVec,
+                                           QPointF& targetPoint) {
+  double hRatio = (targetPoint.x() - bBox.left()) / bBox.width();
+  double vRatio = (targetPoint.y() - bBox.top()) / bBox.height();
+
+  QPointF moveVec = (1.0 - hRatio) * (1.0 - vRatio) * topLeftVec +
+                    (1.0 - hRatio) * vRatio * bottomLeftVec +
+                    hRatio * (1.0 - vRatio) * topRightVec +
+                    hRatio * vRatio * bottomRightVec;
+
+  return targetPoint + moveVec;
+}
+
+//--------------------------------------------------------
+// ハンドル普通のクリック → 拡大／縮小モード
+//--------------------------------------------------------
+
+ActivePointsScaleDragTool::ActivePointsScaleDragTool(TransformHandleId handleId,
+                                                     const QSet<int>& points,
+                                                     const QRectF& handleRect)
+    : ActivePointsDragTool(handleId, points, handleRect)
+    , m_scaleHorizontal(true)
+    , m_scaleVertical(true) {
+  if (m_handleId == Handle_Right || m_handleId == Handle_Left ||
+      m_handleId == Handle_RightEdge || m_handleId == Handle_LeftEdge)
+    m_scaleVertical = false;
+  else if (m_handleId == Handle_Top || m_handleId == Handle_Bottom ||
+           m_handleId == Handle_TopEdge || m_handleId == Handle_BottomEdge)
+    m_scaleHorizontal = false;
+}
+
+//--------------------------------------------------------
+
+void ActivePointsScaleDragTool::onClick(const QPointF& pos,
+                                        const QMouseEvent* e) {
+  m_startPos = pos;
+  // 拡大縮小の基準位置
+  bool isCtrlPressed = (e->modifiers() & Qt::ControlModifier);
+  if (isCtrlPressed)
+    m_centerPos = getOppositeHandlePos();
+  else
+    m_centerPos = getCenterPos();
+  // if (m_tool->IsScaleAroundCenter())
+  //   m_anchorPos = getCenterPos();
+  // else
+  //   m_anchorPos = getOppositeHandlePos();
+}
+
+//--------------------------------------------------------
+
+void ActivePointsScaleDragTool::onDrag(const QPointF& pos,
+                                       const QMouseEvent* e) {
+  // 縦横の変形倍率を計算する
+  QPointF orgVector = pos - m_centerPos;
+  QPointF dstVector = m_startPos - m_centerPos;
+
+  QPointF scaleRatio =
+      QPointF(orgVector.x() / dstVector.x(), orgVector.y() / dstVector.y());
+
+  // ハンドルによって倍率を制限する
+  if (!m_scaleVertical)
+    scaleRatio.setY((e->modifiers() & Qt::ShiftModifier) ? scaleRatio.x()
+                                                         : 1.0);
+  else if (!m_scaleHorizontal)
+    scaleRatio.setX((e->modifiers() & Qt::ShiftModifier) ? scaleRatio.y()
+                                                         : 1.0);
+  else {
+    if (e->modifiers() & Qt::ShiftModifier) {
+      double largerScale = (abs(scaleRatio.x()) > abs(scaleRatio.y()))
+                               ? scaleRatio.x()
+                               : scaleRatio.y();
+      scaleRatio         = QPointF(largerScale, largerScale);
+    }
+  }
+
+  int frame = m_project->getViewFrame();
+  // TODO: 倍率が０に近すぎる場合はreturn
+
+  // 各シェイプに変形を適用
+  for (int s = 0; s < m_orgPoints.size(); s++) {
+    // シェイプを取得
+    OneShape shape = m_shapes.at(s);
+
+    BezierPointList formKey = m_orgPoints.at(s);
+
+    // 倍率に合わせて変形を適用していく
+    QTransform affine;
+    affine = affine.translate(m_centerPos.x(), m_centerPos.y());
+    affine = affine.scale(scaleRatio.x(), scaleRatio.y());
+    affine = affine.translate(-m_centerPos.x(), -m_centerPos.y());
+    // 変形
+    for (auto bp : m_pointsInShapes[s]) {
+      // for (int bp = 0; bp < scaledBPointList.count(); bp++) {
+      formKey[bp].pos          = affine.map(formKey.at(bp).pos);
+      formKey[bp].firstHandle  = affine.map(formKey.at(bp).firstHandle);
+      formKey[bp].secondHandle = affine.map(formKey.at(bp).secondHandle);
+    }
+    // キーを格納
+    shape.shapePairP->setFormKey(frame, shape.fromTo, formKey);
+  }
+}
+
+//--------------------------------------------------------
+// シェイプのハンドル以外をクリック  → 移動モード（＋Shiftで平行移動）
+//--------------------------------------------------------
+
+ActivePointsTranslateDragTool::ActivePointsTranslateDragTool(
+    TransformHandleId handleId, const QSet<int>& points,
+    const QRectF& handleRect)
+    : ActivePointsDragTool(handleId, points, handleRect) {}
+
+//--------------------------------------------------------
+
+void ActivePointsTranslateDragTool::onClick(const QPointF& pos,
+                                            const QMouseEvent*) {
+  m_startPos = pos;
+}
+
+//--------------------------------------------------------
+
+void ActivePointsTranslateDragTool::onDrag(const QPointF& pos,
+                                           const QMouseEvent* e) {
+  // 移動ベクトルを得る
+  QPointF moveVec = pos - m_startPos;
+
+  // Shiftが押されていたら移動量が大きい方のみ残す
+  if (e->modifiers() & Qt::ShiftModifier) {
+    // X方向に平行移動
+    if (abs(moveVec.x()) > abs(moveVec.y())) moveVec.setY(0.0);
+    // Y方向に平行移動
+    else
+      moveVec.setX(0.0);
+  }
+
+  // 移動に合わせ変形を適用していく
+  QTransform affine;
+  affine    = affine.translate(moveVec.x(), moveVec.y());
+  int frame = m_project->getViewFrame();
+
+  // 各シェイプに変形を適用
+  for (int s = 0; s < m_orgPoints.count(); s++) {
+    // シェイプを得る
+    OneShape shape = m_shapes.at(s);
+
+    BezierPointList formKey = m_orgPoints.at(s);
+
+    // 変形
+    for (auto bp : m_pointsInShapes[s]) {
+      // for (int bp = 0; bp < translatedBPointList.count(); bp++) {
+      formKey[bp].pos          = affine.map(formKey.at(bp).pos);
+      formKey[bp].firstHandle  = affine.map(formKey.at(bp).firstHandle);
+      formKey[bp].secondHandle = affine.map(formKey.at(bp).secondHandle);
+    }
+
+    // キーを格納
+    shape.shapePairP->setFormKey(frame, shape.fromTo, formKey);
+  }
+}
+
+//---------------------------------------------------
+// 以下、Undoコマンド
+//---------------------------------------------------
+
+ActivePointsDragToolUndo::ActivePointsDragToolUndo(
+    QList<OneShape>& shapes, QList<BezierPointList>& beforePoints,
+    QList<BezierPointList>& afterPoints, QList<bool>& wasKeyFrame,
+    IwProject* project, int frame)
+    : m_project(project)
+    , m_shapes(shapes)
+    , m_beforePoints(beforePoints)
+    , m_afterPoints(afterPoints)
+    , m_wasKeyFrame(wasKeyFrame)
+    , m_frame(frame)
+    , m_firstFlag(true) {}
+
+//---------------------------------------------------
+
+ActivePointsDragToolUndo::~ActivePointsDragToolUndo() {}
+
+//---------------------------------------------------
+
+void ActivePointsDragToolUndo::undo() {
+  // 各シェイプにポイントをセット
+  for (int s = 0; s < m_shapes.count(); s++) {
+    OneShape shape = m_shapes.at(s);
+
+    // 操作前はキーフレームでなかった場合、キーを消去
+    if (!m_wasKeyFrame.at(s))
+      shape.shapePairP->removeFormKey(m_frame, shape.fromTo);
+    else {
+      BezierPointList beforeFormKey = m_beforePoints.at(s);
+      shape.shapePairP->setFormKey(m_frame, shape.fromTo, beforeFormKey);
+    }
+  }
+
+  // もしこれがカレントなら、シグナルをエミット
+  if (m_project->isCurrent()) {
+    IwApp::instance()->getCurrentProject()->notifyProjectChanged();
+    // 変更されるフレームをinvalidate
+    for (auto shape : m_shapes) {
+      int start, end;
+      shape.shapePairP->getFormKeyRange(start, end, m_frame, shape.fromTo);
+      IwTriangleCache::instance()->invalidateCache(
+          start, end, m_project->getParentShape(shape.shapePairP));
+    }
+  }
+}
+
+//---------------------------------------------------
+
+void ActivePointsDragToolUndo::redo() {
+  // Undo登録時にはredoを行わないよーにする
+  if (m_firstFlag) {
+    m_firstFlag = false;
+    return;
+  }
+
+  // 各シェイプにポイントをセット
+  for (int s = 0; s < m_shapes.count(); s++) {
+    OneShape shape               = m_shapes.at(s);
+    BezierPointList afterFormKey = m_afterPoints.at(s);
+    shape.shapePairP->setFormKey(m_frame, shape.fromTo, afterFormKey);
+  }
+
+  // もしこれがカレントなら、シグナルをエミット
+  if (m_project->isCurrent()) {
+    IwApp::instance()->getCurrentProject()->notifyProjectChanged();
+
+    // 変更されるフレームをinvalidate
+    for (auto shape : m_shapes) {
+      int start, end;
+      shape.shapePairP->getFormKeyRange(start, end, m_frame, shape.fromTo);
+      IwTriangleCache::instance()->invalidateCache(
+          start, end, m_project->getParentShape(shape.shapePairP));
+    }
+  }
+}

--- a/sources/reshapetool.h
+++ b/sources/reshapetool.h
@@ -32,6 +32,11 @@ class ReshapeTool : public IwTool {
   OneShape getClickedShapeAndIndex(int& pointIndex, int& handleId,
                                    const QMouseEvent* e);
 
+  // show handles for transforming active points
+  bool m_transformHandles;
+  bool m_ctrlPressed;
+  QRectF m_handleRect;
+
 public:
   ReshapeTool();
   ~ReshapeTool();
@@ -79,6 +84,9 @@ public:
 
   bool setSpecialShapeColor(OneShape) override;
   bool setSpecialGridColor(int gId, bool isVertical) override;
+
+  bool isTransformHandlesEnabled() { return m_transformHandles; }
+  void enableTransformHandles(bool on) { m_transformHandles = on; }
 
 protected:
   // Ctrl+矢印キーで0.25ピクセル分ずつ移動させる

--- a/sources/tooloptionpanel.cpp
+++ b/sources/tooloptionpanel.cpp
@@ -8,6 +8,7 @@
 #include <QStackedWidget>
 #include <QVBoxLayout>
 #include <QLabel>
+#include <QCheckBox>
 
 #include "iwapp.h"
 #include "iwprojecthandle.h"
@@ -21,6 +22,7 @@
 #include "freehanddialog.h"
 
 #include "myslider.h"
+#include "reshapetool.h"
 
 //------------------------------------------
 // ReshapeTool "Lock Points"コマンドの距離の閾値のスライダ
@@ -30,6 +32,13 @@ ReshapeToolOptionPanel::ReshapeToolOptionPanel(QWidget* parent)
     : QWidget(parent) {
   // オブジェクトの宣言
   m_lockThresholdSlider = new MyIntSlider(1, 500, this);
+  m_transformHandlesCB  = new QCheckBox(tr("Transform Active Points"), this);
+
+  //--- 初期値状態の設定
+  ReshapeTool* tool = dynamic_cast<ReshapeTool*>(IwTool::getTool("T_Reshape"));
+  if (tool) {
+    m_transformHandlesCB->setChecked(tool->isTransformHandlesEnabled());
+  }
 
   // レイアウト
   QVBoxLayout* mainLay = new QVBoxLayout();
@@ -38,6 +47,7 @@ ReshapeToolOptionPanel::ReshapeToolOptionPanel(QWidget* parent)
   {
     mainLay->addWidget(new QLabel(tr("Lock threshold:")), 0);
     mainLay->addWidget(m_lockThresholdSlider, 0);
+    mainLay->addWidget(m_transformHandlesCB, 0, Qt::AlignLeft);
     mainLay->addStretch(1);
   }
   setLayout(mainLay);
@@ -49,6 +59,8 @@ ReshapeToolOptionPanel::ReshapeToolOptionPanel(QWidget* parent)
   // スライダがいじられたらパラメータに反映
   connect(m_lockThresholdSlider, SIGNAL(valueChanged(bool)), this,
           SLOT(onLockThresholdSliderChanged()));
+  connect(m_transformHandlesCB, SIGNAL(clicked(bool)), this,
+          SLOT(onTransformHandlesCBClicked(bool)));
 
   onProjectSwitched();
 }
@@ -67,6 +79,12 @@ void ReshapeToolOptionPanel::onLockThresholdSliderChanged() {
   if (!project) return;
   Preferences::instance()->setLockThreshold(m_lockThresholdSlider->value());
 
+  IwApp::instance()->getCurrentProject()->notifyViewSettingsChanged();
+}
+
+void ReshapeToolOptionPanel::onTransformHandlesCBClicked(bool on) {
+  ReshapeTool* tool = dynamic_cast<ReshapeTool*>(IwTool::getTool("T_Reshape"));
+  if (tool) tool->enableTransformHandles(on);
   IwApp::instance()->getCurrentProject()->notifyViewSettingsChanged();
 }
 

--- a/sources/tooloptionpanel.h
+++ b/sources/tooloptionpanel.h
@@ -14,6 +14,7 @@ class QStackedWidget;
 class IwTool;
 
 class MyIntSlider;
+class QCheckBox;
 
 //------------------------------------------
 // ReshapeTool "Lock Points"コマンドの距離の閾値のスライダ
@@ -23,12 +24,14 @@ class ReshapeToolOptionPanel : public QWidget {
   Q_OBJECT
 
   MyIntSlider* m_lockThresholdSlider;
+  QCheckBox* m_transformHandlesCB;
 
 public:
   ReshapeToolOptionPanel(QWidget* parent);
 protected slots:
   void onProjectSwitched();
   void onLockThresholdSliderChanged();
+  void onTransformHandlesCBClicked(bool);
 };
 
 //------------------------------------------


### PR DESCRIPTION
This PR will add `Transform Active Points` option to the Reshape Tool options for transforming a part of the shape.

![image](https://user-images.githubusercontent.com/17974955/231400018-e130e6d1-d391-45cd-a9f0-d12a332bf296.png)

When active, a green rectangle appears around the active control points. You can transform active points by using handles in the rectangle, just like using the Transform Tool.