### PR TITLE
Save MainWindow State

### DIFF
--- a/sources/layeroptionpanel.cpp
+++ b/sources/layeroptionpanel.cpp
@@ -65,8 +65,10 @@ void LayerOptionUndo::redo() {
 
 LayerOptionPanel::LayerOptionPanel(QWidget* parent)
     : QDockWidget(tr("Layer Options"), parent), m_undo(nullptr) {
-  // The dock widget cannot be closed, moved, or floated.
-  setFeatures(QDockWidget::NoDockWidgetFeatures);
+  setObjectName("LayerOptionPanel");
+  // The dock widget cannot be closed
+  setFeatures(QDockWidget::DockWidgetMovable |
+              QDockWidget::DockWidgetFloatable);
   m_brightness = new MyIntSlider(-255, 255, this);
   m_contrast   = new MyIntSlider(-255, 255, this);
 

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -687,6 +687,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
   QString fp = IwFolders::getMyProfileFolderPath() + "/mainwindow.ini";
   QSettings settings(fp, QSettings::IniFormat);
   restoreGeometry(settings.value("MainWindowGeometry").toByteArray());
+  restoreState(settings.value("MainWindowState").toByteArray());
 
   showMessageOnStatusBar(tr("IwaWarper launched."), 10000);
 }
@@ -764,6 +765,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
   QString fp = IwFolders::getMyProfileFolderPath() + "/mainwindow.ini";
   QSettings settings(fp, QSettings::IniFormat);
   settings.setValue("MainWindowGeometry", saveGeometry());
+  settings.setValue("MainWindowState", saveState());
 
   IwImageCache::instance()->clear();
   m_viewer->deleteTextures();

--- a/sources/shapetreewindow.cpp
+++ b/sources/shapetreewindow.cpp
@@ -1155,9 +1155,11 @@ void ShapeTree::contextMenuEvent(QContextMenuEvent* e) {
 //----------------------------------------------
 
 ShapeTreeWindow::ShapeTreeWindow(QWidget* parent) : QDockWidget(parent) {
+  setObjectName("ShapeTreeWindow");
   setWindowTitle(tr("Shape Tree"));
-  // The dock widget cannot be closed, moved, or floated.
-  setFeatures(QDockWidget::NoDockWidgetFeatures);
+  // The dock widget cannot be closed
+  setFeatures(QDockWidget::DockWidgetMovable |
+              QDockWidget::DockWidgetFloatable);
   m_selectByTagBtn            = new QPushButton(tr("Select By Tag"), this);
   QPushButton* openTagEditBtn = new QPushButton(tr("Edit Tags"), this);
 

--- a/sources/timelinewindow.cpp
+++ b/sources/timelinewindow.cpp
@@ -1517,8 +1517,10 @@ int TimeLinePanel::xPosToFrameIndexAndBorder(int xPos, bool& isBorder) {
 
 TimeLineWindow::TimeLineWindow(QWidget* parent)
     : QDockWidget(tr("Timeline"), parent) {
-  // The dock widget cannot be closed, moved, or floated.
-  setFeatures(QDockWidget::NoDockWidgetFeatures);
+  setObjectName("TimeLineWindow");
+  // The dock widget cannot be closed
+  setFeatures(QDockWidget::DockWidgetMovable |
+              QDockWidget::DockWidgetFloatable);
   // setTitleBarWidget(new QWidget(this));
   // オブジェクトの宣言
   m_itemListHead            = new ItemListHead(this);

--- a/sources/toolbox.cpp
+++ b/sources/toolbox.cpp
@@ -25,9 +25,11 @@ public:
 };
 
 ToolBoxDock::ToolBoxDock(QWidget* parent) : QDockWidget(parent) {
+  setObjectName("ToolBoxDock");
   setFixedWidth(35);
-  // The dock widget cannot be closed, moved, or floated.
-  setFeatures(QDockWidget::NoDockWidgetFeatures);
+  // The dock widget cannot be closed
+  setFeatures(QDockWidget::DockWidgetMovable |
+              QDockWidget::DockWidgetFloatable);
   ToolBox* toolBox = new ToolBox(this);
   setWidget(toolBox);
 }

--- a/sources/tooloptionpanel.cpp
+++ b/sources/tooloptionpanel.cpp
@@ -93,9 +93,11 @@ void ReshapeToolOptionPanel::onTransformHandlesCBClicked(bool on) {
 
 ToolOptionPanel::ToolOptionPanel(QWidget* parent)
     : QDockWidget(tr("Tool Options"), parent) {
+  setObjectName("ToolOptionPanel");
   setFixedWidth(220);
-  // The dock widget cannot be closed, moved, or floated.
-  setFeatures(QDockWidget::NoDockWidgetFeatures);
+  // The dock widget cannot be closed
+  setFeatures(QDockWidget::DockWidgetMovable |
+              QDockWidget::DockWidgetFloatable);
   // オブジェクトの宣言
   m_stackedPanels = new QStackedWidget(this);
 


### PR DESCRIPTION
This PR saves the state of this mainwindow's toolbars and dockwidgets. 
Also enabled the panels to be floated and moved to another dock position.