### PR TITLE
Nearest Neighbor Resampling & TGA Output

### DIFF
--- a/sources/iwrenderinstance.h
+++ b/sources/iwrenderinstance.h
@@ -45,6 +45,7 @@ class MapTrianglesToRaster_Worker : public QRunnable {
   bool* m_subPointOccupation;
   int m_subAmount;
   AlphaMode m_alphaMode;
+  ResampleMode m_resampleMode;
   const QImage m_shapeAlphaImg;
 
   void run() override;
@@ -55,7 +56,8 @@ public:
                               QPointF sampleOffset, QPointF outputOffset,
                               TRaster64P outRas, TRaster64P srcRas,
                               bool* subPointOccupation, int subAmount,
-                              AlphaMode alphaMode, QImage shapeAlphaImg)
+                              AlphaMode alphaMode, ResampleMode resampleMode,
+                              QImage shapeAlphaImg)
       : m_from(from)
       , m_to(to)
       , m_model(model)
@@ -67,6 +69,7 @@ public:
       , m_subPointOccupation(subPointOccupation)
       , m_subAmount(subAmount)
       , m_alphaMode(alphaMode)
+      , m_resampleMode(resampleMode)
       , m_shapeAlphaImg(shapeAlphaImg) {}
 };
 

--- a/sources/outputsettings.cpp
+++ b/sources/outputsettings.cpp
@@ -77,6 +77,8 @@ QString OutputSettings::getStandardExtension(QString saver) {
     return QString("tif");
   else if (saver == Saver_SGI)
     return QString("sgi");
+  else if (saver == Saver_TGA)
+    return QString("tga");
 
   else
     return QString("");

--- a/sources/outputsettings.h
+++ b/sources/outputsettings.h
@@ -12,6 +12,7 @@
 #define Saver_TIFF "TIFF"
 #define Saver_SGI "SGI"
 #define Saver_PNG "PNG"
+#define Saver_TGA "TGA"
 
 #include <QString>
 #include <QMap>

--- a/sources/outputsettingsdialog.cpp
+++ b/sources/outputsettingsdialog.cpp
@@ -73,7 +73,7 @@ OutputSettingsDialog::OutputSettingsDialog()
   m_shapeTagCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 
   QStringList saverList;
-  saverList << Saver_PNG << Saver_TIFF << Saver_SGI;
+  saverList << Saver_PNG << Saver_TIFF << Saver_SGI << Saver_TGA;
   m_saverCombo->addItems(saverList);
 
   parametersBtn->setFocusPolicy(Qt::NoFocus);

--- a/sources/rendersettings.cpp
+++ b/sources/rendersettings.cpp
@@ -22,6 +22,7 @@ QStringList precisionStrList = (QStringList() << "Linear"
 RenderSettings::RenderSettings()
     : m_warpPrecision(4)
     , m_alphaMode(SourceAlpha)
+    , m_resampleMode(AreaAverage)
     , m_faceSizeThreshold(25.0)
     , m_imageShrink(1)
     , m_antialias(true) {}
@@ -45,6 +46,7 @@ void RenderSettings::saveData(QXmlStreamWriter& writer) {
   writer.writeTextElement("faceSizeThreshold",
                           QString::number(m_faceSizeThreshold));
   writer.writeTextElement("alphaMode", QString::number((int)m_alphaMode));
+  writer.writeTextElement("resampleMode", QString::number((int)m_resampleMode));
   writer.writeTextElement("imageShrink", QString::number((int)m_imageShrink));
   writer.writeTextElement("antialias", (m_antialias) ? "1" : "0");
   writer.writeEndElement();
@@ -61,6 +63,8 @@ void RenderSettings::loadData(QXmlStreamReader& reader) {
           m_faceSizeThreshold = reader.readElementText().toDouble();
         else if (reader.name() == "alphaMode")
           m_alphaMode = (AlphaMode)(reader.readElementText().toInt());
+        else if (reader.name() == "resampleMode")
+          m_resampleMode = (ResampleMode)(reader.readElementText().toInt());
         else if (reader.name() == "imageShrink")
           m_imageShrink = (AlphaMode)(reader.readElementText().toInt());
         else if (reader.name() == "antialias")

--- a/sources/rendersettings.h
+++ b/sources/rendersettings.h
@@ -9,6 +9,7 @@ class QXmlStreamWriter;
 class QXmlStreamReader;
 
 enum AlphaMode { SourceAlpha = 0, ShapeAlpha };
+enum ResampleMode { AreaAverage = 0, NearestNeighbor };
 
 class RenderSettings {
   // メッシュ再帰分割の回数
@@ -18,6 +19,9 @@ class RenderSettings {
   // アルファを、素材で抜くか、シェイプの形に抜くか
   AlphaMode m_alphaMode;
 
+  // リサンプル
+  ResampleMode m_resampleMode;
+
   // ラスター画像の縮小読み込み
   int m_imageShrink;
 
@@ -26,20 +30,23 @@ class RenderSettings {
 public:
   RenderSettings();
 
-  int getWarpPrecision() { return m_warpPrecision; }
-  void setWarpPrecision(int prec);
+  int getWarpPrecision() const { return m_warpPrecision; }
+  void setWarpPrecision(const int prec);
 
-  double getFaceSizeThreshold() { return m_faceSizeThreshold; }
-  void setFaceSizeThreshold(double thres) { m_faceSizeThreshold = thres; }
+  double getFaceSizeThreshold() const { return m_faceSizeThreshold; }
+  void setFaceSizeThreshold(const double thres) { m_faceSizeThreshold = thres; }
 
-  AlphaMode getAlphaMode() { return m_alphaMode; }
-  void setAlphaMode(AlphaMode mode) { m_alphaMode = mode; }
+  AlphaMode getAlphaMode() const { return m_alphaMode; }
+  void setAlphaMode(const AlphaMode mode) { m_alphaMode = mode; }
 
-  int getImageShrink() { return m_imageShrink; }
-  void setImageShrink(int imageShrink) { m_imageShrink = imageShrink; }
+  ResampleMode getResampleMode() const { return m_resampleMode; }
+  void setResampleMode(const ResampleMode mode) { m_resampleMode = mode; }
 
-  bool getAntialias() { return m_antialias; }
-  void setAntialias(bool on) { m_antialias = on; }
+  int getImageShrink() const { return m_imageShrink; }
+  void setImageShrink(const int imageShrink) { m_imageShrink = imageShrink; }
+
+  bool getAntialias() const { return m_antialias; }
+  void setAntialias(const bool on) { m_antialias = on; }
 
   // 保存/ロード
   void saveData(QXmlStreamWriter& writer);

--- a/sources/settingsdialog.cpp
+++ b/sources/settingsdialog.cpp
@@ -33,6 +33,7 @@ SettingsDialog::SettingsDialog()
   m_warpPrecisionSlider = new MyIntSlider(0, 5, this);
   m_faceSizeThresSlider = new MyIntSlider(10, 50, this);
   m_alphaModeCombo      = new QComboBox(this);
+  m_resampleModeCombo   = new QComboBox(this);
   m_imageShrinkSlider   = new MyIntSlider(1, 4, this);
   m_antialiasCheckBox   = new QCheckBox(tr("Shape Antialias"), this);
 
@@ -46,6 +47,9 @@ SettingsDialog::SettingsDialog()
   aModeList << "Source"
             << "Shape";
   m_alphaModeCombo->addItems(aModeList);
+
+  m_resampleModeCombo->addItem(tr("Area Average"), AreaAverage);
+  m_resampleModeCombo->addItem(tr("Nearest Neighbor"), NearestNeighbor);
 
   //-- レイアウト
   QVBoxLayout* mainLay = new QVBoxLayout();
@@ -64,6 +68,9 @@ SettingsDialog::SettingsDialog()
     mainLay->addWidget(new QLabel(tr("Alpha Mode:")), 0);
     mainLay->addWidget(m_alphaModeCombo, 0);
     mainLay->addSpacing(3);
+    mainLay->addWidget(new QLabel(tr("Resample Mode:")), 0);
+    mainLay->addWidget(m_resampleModeCombo, 0);
+    mainLay->addSpacing(3);
     mainLay->addWidget(m_antialiasCheckBox, 0);
     mainLay->addSpacing(3);
     mainLay->addWidget(new QLabel(tr("Image Shrink:")), 0);
@@ -81,6 +88,8 @@ SettingsDialog::SettingsDialog()
           SLOT(onFaceSizeValueChanged(bool)));
   connect(m_alphaModeCombo, SIGNAL(activated(int)), this,
           SLOT(onAlphaModeComboActivated(int)));
+  connect(m_resampleModeCombo, SIGNAL(activated(int)), this,
+          SLOT(onResampleModeComboActivated()));
   connect(m_imageShrinkSlider, SIGNAL(valueChanged(bool)), this,
           SLOT(onImageShrinkChanged(bool)));
   connect(m_antialiasCheckBox, SIGNAL(clicked(bool)), this,
@@ -126,6 +135,8 @@ void SettingsDialog::onProjectSwitched() {
     m_warpPrecisionSlider->setValue(settings->getWarpPrecision());
     m_faceSizeThresSlider->setValue(settings->getFaceSizeThreshold());
     m_alphaModeCombo->setCurrentIndex((int)settings->getAlphaMode());
+    m_resampleModeCombo->setCurrentIndex(
+        m_resampleModeCombo->findData((int)settings->getResampleMode()));
     m_imageShrinkSlider->setValue(settings->getImageShrink());
     m_antialiasCheckBox->setChecked(settings->getAntialias());
   }
@@ -189,6 +200,20 @@ void SettingsDialog::onAlphaModeComboActivated(int index) {
   if (index == (int)settings->getAlphaMode()) return;
 
   settings->setAlphaMode((AlphaMode)index);
+}
+
+void SettingsDialog::onResampleModeComboActivated() {
+  // 現在のプロジェクトのOutputSettingsを取得
+  IwProject* project = IwApp::instance()->getCurrentProject()->getProject();
+  if (!project) return;
+  RenderSettings* settings = project->getRenderSettings();
+  if (!settings) return;
+
+  ResampleMode rMode =
+      (ResampleMode)(m_resampleModeCombo->currentData().toInt());
+  if (rMode == settings->getResampleMode()) return;
+
+  settings->setResampleMode(rMode);
 }
 
 void SettingsDialog::onImageShrinkChanged(bool isDragging) {

--- a/sources/settingsdialog.h
+++ b/sources/settingsdialog.h
@@ -20,6 +20,7 @@ class SettingsDialog : public IwDialog {
   MyIntSlider* m_warpPrecisionSlider;
   MyIntSlider* m_faceSizeThresSlider;
   QComboBox* m_alphaModeCombo;
+  QComboBox* m_resampleModeCombo;
   MyIntSlider* m_imageShrinkSlider;
   QCheckBox* m_antialiasCheckBox;
 
@@ -40,6 +41,7 @@ protected slots:
   void onPrecisionValueChanged(bool isDragging);
   void onFaceSizeValueChanged(bool isDragging);
   void onAlphaModeComboActivated(int index);
+  void onResampleModeComboActivated();
   void onImageShrinkChanged(bool isDragging);
   void onAntialiasClicked(bool on);
 };


### PR DESCRIPTION
This PR enables to warp aliased TGA (which is common format in Japanese animation industry) and render in the same format with keeping the image aliased.

**PLEASE NOTE:** 
Warping an aliased image may enhance the jaggedness of the lines.
Converting the warped image to vector with OpenToonz to smooth the lines and exporting again to an aliased TGA will improve the result.