### PR TITLE
Point weight

### DIFF
--- a/sources/circletool.cpp
+++ b/sources/circletool.cpp
@@ -214,7 +214,8 @@ CreateCircleShapeUndo::CreateCircleShapeUndo(QRectF& rect, IwProject* prj,
   bpList << p[0] << p[1] << p[2] << p[3];
 
   CorrPointList cpList;
-  cpList << 1.5 << 2.5 << 3.5 << 0.5;
+  CorrPoint c[4] = {{1.5, 1.0}, {2.5, 1.0}, {3.5, 1.0}, {0.5, 1.0}};
+  cpList << c[0] << c[1] << c[2] << c[3];
 
   // Œ»Ý‚ÌƒtƒŒ[ƒ€
   int frame = m_project->getViewFrame();

--- a/sources/freehandtool.cpp
+++ b/sources/freehandtool.cpp
@@ -335,7 +335,8 @@ void FreeHandTool::createShape() {
 
   CorrPointList cpList;
   for (int cp = 0; cp < 4; cp++) {
-    cpList.push_back((double)((bpCount - 1) * cp) / ((m_isClosed) ? 4.0 : 3.0));
+    cpList.push_back(
+        {(double)((bpCount - 1) * cp) / ((m_isClosed) ? 4.0 : 3.0), 1.0});
   }
 
   m_currentShape =

--- a/sources/halfedge.h
+++ b/sources/halfedge.h
@@ -21,21 +21,29 @@ public:
   // ワープ後の座標
   QVector3D to_pos;
 
+  double from_weight, to_weight;
+
   // この頂点を始点にもつハーフエッジの1つ
   Halfedge* halfedge = nullptr;
   // 線分制約（動かない）かどうか
   bool constrained = false;
 
   HEVertex(double _x, double _y, double _z)
-      : from_pos(_x, _y, _z), halfedge(nullptr) {
+      : from_pos(_x, _y, _z)
+      , halfedge(nullptr)
+      , from_weight(1.0)
+      , to_weight(1.0) {
     to_pos = from_pos;
   }
   HEVertex(const QPointF& _pos, double depth)
       : HEVertex(_pos.x(), _pos.y(), depth) {}
 
-  HEVertex(const QPointF& _from_pos, const QPointF& _to_pos, double depth)
+  HEVertex(const QPointF& _from_pos, const QPointF& _to_pos, double depth,
+           double _from_weight = 1.0, double _to_weight = 1.0)
       : from_pos(_from_pos.x(), _from_pos.y(), depth)
-      , to_pos(_to_pos.x(), _to_pos.y(), depth) {}
+      , to_pos(_to_pos.x(), _to_pos.y(), depth)
+      , from_weight(_from_weight)
+      , to_weight(_to_weight) {}
 
   bool operator==(const HEVertex& v);
 

--- a/sources/iwrenderinstance.h
+++ b/sources/iwrenderinstance.h
@@ -32,7 +32,9 @@ struct CorrVector {
   QPointF to_p[2];
   int stackOrder;  // レイヤインデックス ＝ 重ね順
   bool isEdge;     // 輪郭ならtrue, シェイプ由来ならtrue
-  int indices[2];  // samplePointsのインデックス
+  double from_weight[2];
+  double to_weight[2];
+  // int indices[2];  // samplePointsのインデックス
 };
 
 class MapTrianglesToRaster_Worker : public QRunnable {

--- a/sources/iwshapepairselection.cpp
+++ b/sources/iwshapepairselection.cpp
@@ -37,7 +37,7 @@
 class DeleteCorrPointUndo : public QUndoCommand {
   ShapePair* m_shape;
   IwProject* m_project;
-  QMap<int, double> m_deletedCorrPos[2];
+  QMap<int, CorrPoint> m_deletedCorrPos[2];
   int m_deletedIndex;
 
 public:
@@ -517,6 +517,7 @@ void IwShapePairSelection::onDeleteCorrPoint() {
 
   // 対応点選択をクリア
   setActiveCorrPoint(OneShape(), -1);
+  IwApp::instance()->getCurrentSelection()->notifySelectionChanged();
 }
 
 //---------------------------------------------------

--- a/sources/iwtool.cpp
+++ b/sources/iwtool.cpp
@@ -150,6 +150,9 @@ void IwTool::drawCorrLine(OneShape shape)
   // 対応点の座標リストを得る
   QList<QPointF> corrPoints =
       shape.shapePairP->getCorrPointPositions(frame, shape.fromTo);
+  // ウェイトのリストも得る
+  QList<double> corrWeights =
+      shape.shapePairP->getCorrPointWeights(frame, shape.fromTo);
 
   // 名前
   int shapeName = layer->getNameFromShapePair(shape);
@@ -179,10 +182,16 @@ void IwTool::drawCorrLine(OneShape shape)
     glPopName();
 
     // テキストの描画
-    glColor3d(cNumberCol[0], cNumberCol[1], cNumberCol[2]);
-    // TODO
-    // m_viewer->renderText(5.0, -15.0, 0.0,QString::number(p+1),f);
-
+    // ウェイトが1じゃない場合に描画する
+    double weight = corrWeights.at(p);
+    if (weight != 1.) {
+      glColor3d(cNumberCol[0], cNumberCol[1], cNumberCol[2]);
+      GLdouble model[16];
+      glGetDoublev(GL_MODELVIEW_MATRIX, model);
+      m_viewer->renderText(model[12] + 5.0, model[13] - 15.0,
+                           QString::number(weight),
+                           QFont("Helvetica", 10, QFont::Normal));
+    }
     glPopMatrix();
   }
 }

--- a/sources/keycontainer.h
+++ b/sources/keycontainer.h
@@ -25,12 +25,24 @@ typedef struct BezierPoint {
   QPointF secondHandle;
 } BezierPoint;
 
+// 対応点
+typedef struct CorrPoint {
+  // 対応点のベジエ位置
+  // 値は 0～m_bezierPointCount(Closed)
+  //      0～m_bezierPointCount-1(Open)
+  double value;
+  // 対応点のウェイト（歪みを引き寄せる）
+  double weight;
+
+  bool operator==(const CorrPoint& other) const {
+    return (value == other.value && weight == other.weight);
+  }
+} CorrPoint;
+
 // シェイプ形状のデータ構造（データ数＝コントロールポイント数）
 typedef QList<BezierPoint> BezierPointList;
 // 対応点情報のデータ構造（データ数＝Corrポイント数）
-// 値は 0～m_bezierPointCount(Closed)
-//      0～m_bezierPointCount-1(Open)
-typedef QList<double> CorrPointList;
+typedef QList<CorrPoint> CorrPointList;
 
 template <class T>
 class KeyContainer {

--- a/sources/pentool.cpp
+++ b/sources/pentool.cpp
@@ -66,7 +66,8 @@ bool PenTool::leftButtonDown(const QPointF& pos, const QMouseEvent* e) {
 
     // CorrPointListçÏÇÈ
     CorrPointList cpList;
-    cpList << 0 << 0 << 0 << 0;
+    CorrPoint cp = {0., 1.};
+    cpList << cp << cp << cp << cp;
 
     m_editingShape = new ShapePair(frame, false, bpList, cpList, 0.01f);
 
@@ -315,11 +316,11 @@ void PenTool::updateCorrPoints(int fromTo) {
 
   if (m_editingShape->isClosed()) {
     for (int c = 0; c < 4; c++) {
-      cpList.push_back((double)(pointAmount) * (double)c / 4.0);
+      cpList.push_back({(double)(pointAmount) * (double)c / 4.0, 1.0});
     }
   } else {
     for (int c = 0; c < 4; c++) {
-      cpList.push_back((double)(pointAmount - 1) * (double)c / 3.0);
+      cpList.push_back({(double)(pointAmount - 1) * (double)c / 3.0, 1.0});
     }
   }
 

--- a/sources/pointdragtool.cpp
+++ b/sources/pointdragtool.cpp
@@ -271,25 +271,23 @@ int TranslatePointDragTool::calculateSnap(QPointF& pos) {
                      std::abs(posAfter.y() - pos.y()) < thres_dist.y()) {
             minimumW = pointAfter;
             ret      = (int)minimumW;
-          }
-          else { // 対応点へのスナップ
-            CorrPointList corrs = shapePair->getCorrPointList(frame, fromTo);
-            double minDiff = 100.0;
+          } else {  // 対応点へのスナップ
+            CorrPointList corrs   = shapePair->getCorrPointList(frame, fromTo);
+            double minDiff        = 100.0;
             double nearestCorrPos = 0.;
             for (auto corrPos : corrs) {
-              double tmpDiff = w - corrPos;
+              double tmpDiff = w - corrPos.value;
               if (abs(minDiff) > abs(tmpDiff)) {
-                minDiff = tmpDiff;
-                nearestCorrPos = corrPos;
+                minDiff        = tmpDiff;
+                nearestCorrPos = corrPos.value;
               }
             }
             QPointF posCorr =
-              shapePair->getBezierPosFromValue(frame, fromTo, nearestCorrPos);
+                shapePair->getBezierPosFromValue(frame, fromTo, nearestCorrPos);
             if (std::abs(posCorr.x() - pos.x()) < thres_dist.x() &&
-              std::abs(posCorr.y() - pos.y()) < thres_dist.y()) {
+                std::abs(posCorr.y() - pos.y()) < thres_dist.y()) {
               minimumW = nearestCorrPos;
-            }
-            else // 線上へのスナップ
+            } else  // 線上へのスナップ
               minimumW = w;
           }
           minimumDist  = dist;
@@ -496,11 +494,10 @@ void TranslatePointDragTool::draw(const QPointF& onePixelLength) {
     BezierPointList bPList =
         m_snapTarget.shapePairP->getBezierPointList(frame, m_snapTarget.fromTo);
 
-
     // 対応点の描画
     glColor3d(1.0, 1.0, 0.0);
-    QList<QPointF> corrPoints =
-      m_snapTarget.shapePairP->getCorrPointPositions(frame, m_snapTarget.fromTo);
+    QList<QPointF> corrPoints = m_snapTarget.shapePairP->getCorrPointPositions(
+        frame, m_snapTarget.fromTo);
     for (auto corrP : corrPoints) {
       glPushMatrix();
       glTranslated(corrP.x(), corrP.y(), 0.0);

--- a/sources/projectutils.cpp
+++ b/sources/projectutils.cpp
@@ -203,7 +203,7 @@ void ProjectUtils::deleteFormPoints(QMap<ShapePair*, QList<int>>& pointList) {
           CorrPointList cpList = corrItr.value();
           // ポイント全てに、「つめる割合」を掛けていく
           for (int cp = 0; cp < cpList.size(); cp++)
-            cpList[cp] *= corrShrinkRatio;
+            cpList[cp].value *= corrShrinkRatio;
           // 値を上書きで戻す
           corrData.insert(corrItr.key(), cpList);
         }
@@ -299,7 +299,7 @@ void ProjectUtils::deleteFormPoints(QMap<ShapePair*, QList<int>>& pointList) {
           CorrPointList cpList = corrItr.value();
           // ポイント全てに、「つめる割合」を掛けていく
           for (int cp = 0; cp < cpList.size(); cp++) {
-            double tmpCorr = cpList.at(cp);
+            double tmpCorr = cpList.at(cp).value;
             int k1         = (int)tmpCorr;
             double ratio   = tmpCorr - (double)k1;
             int k2         = (k1 + 1 >= oldPointAmount) ? 0 : k1 + 1;
@@ -311,7 +311,7 @@ void ProjectUtils::deleteFormPoints(QMap<ShapePair*, QList<int>>& pointList) {
             // 補間後、Corr値が０を超えた場合クランプする
             if (newCorr >= remainingPointAmount)
               newCorr -= remainingPointAmount;
-            cpList.replace(cp, newCorr);
+            cpList.replace(cp, {newCorr, cpList.at(cp).weight});
           }
           // 値を上書きで戻す
           corrData.insert(corrItr.key(), cpList);

--- a/sources/sceneviewer.h
+++ b/sources/sceneviewer.h
@@ -73,6 +73,9 @@ public:
     m_vRuler = vRuler;
   }
 
+  void renderText(double x, double y, const QString &str,
+                  const QFont &font = QFont());
+
 protected:
   void initializeGL() final override;
   void resizeGL(int width, int height) final override;
@@ -105,9 +108,6 @@ protected:
   void keyReleaseEvent(QKeyEvent *e) final override;
 
   void wheelEvent(QWheelEvent *) final override;
-
-  void renderText(double x, double y, const QString &str,
-                  const QFont &font = QFont());
 
 protected slots:
   // テクスチャインデックスを得る。無ければロードして登録

--- a/sources/shapeoptionsdialog.h
+++ b/sources/shapeoptionsdialog.h
@@ -24,15 +24,22 @@ class ShapeOptionsDialog : public IwDialog {
 
   // 現在選択されているシェイプ
   QList<OneShape> m_selectedShapes;
+  // 選択中の対応点
+  QPair<OneShape, int> m_activeCorrPoint;
 
   // 対応点の密度スライダ
   QSlider* m_edgeDensitySlider;
   QLineEdit* m_edgeDensityEdit;
 
+  // ウェイトのスライダ(大きいほどメッシュを引き寄せる)
+  QSlider* m_weightSlider;
+  QLineEdit* m_weightEdit;
+
 public:
   ShapeOptionsDialog();
 
   void setDensity(int value);
+  void setWeight(double weight);
 
 protected:
   void showEvent(QShowEvent*);
@@ -42,9 +49,12 @@ protected slots:
 
   void onSelectionSwitched(IwSelection*, IwSelection*);
   void onSelectionChanged(IwSelection*);
+  void onViewFrameChanged();
 
   void onEdgeDensitySliderMoved(int val);
   void onEdgeDensityEditEdited();
+  void onWeightSliderMoved(int val);
+  void onWeightEditEdited();
 };
 
 //-------------------------------------
@@ -71,4 +81,20 @@ public:
   void redo();
 };
 
+class ChangeWeightUndo : public QUndoCommand {
+  IwProject* m_project;
+  QList<QPair<OneShape, int>>
+      m_targetCorrs;  // シェイプ全体の場合はsecondに-1を入れる
+  QList<double> m_beforeWeights;
+  double m_afterWeight;
+  int m_frame;
+  QList<OneShape> m_wasKeyShapes;
+
+public:
+  ChangeWeightUndo(QList<QPair<OneShape, int>>& targets, double afterWeight,
+                   IwProject* project);
+
+  void undo();
+  void redo();
+};
 #endif

--- a/sources/shapepair.h
+++ b/sources/shapepair.h
@@ -171,10 +171,15 @@ public:
 
   // 対応点の座標リストを得る
   QList<QPointF> getCorrPointPositions(int frame, int fromTo);
+  // 対応点のウェイトのリストを得る
+  QList<double> getCorrPointWeights(int frame, int fromTo);
 
   // 現在のフレームのCorrenspondence(対応点)間を分割した点の分割値を得る
   QList<double> getDiscreteCorrValues(const QPointF& onePix, int frame,
                                       int fromTo);
+
+  // 現在のフレームのCorrenspondence(対応点)間を分割した点のウェイト値を得る
+  QList<double> getDiscreteCorrWeights(int frame, int fromTo);
 
   // ベジエ値から座標値を計算する
   QPointF getBezierPosFromValue(int frame, int fromTo, double bezierValue);

--- a/sources/squaretool.cpp
+++ b/sources/squaretool.cpp
@@ -186,7 +186,8 @@ CreateSquareShapeUndo::CreateSquareShapeUndo(QRectF& rect, IwProject* prj,
   bpList << p[0] << p[1] << p[2] << p[3];
 
   CorrPointList cpList;
-  cpList << 0 << 1 << 2 << 3;
+  CorrPoint c[4] = {{0., 1.}, {1., 1.}, {2., 1.}, {3., 1.}};
+  cpList << c[0] << c[1] << c[2] << c[3];
 
   // Œ»Ý‚ÌƒtƒŒ[ƒ€
   int frame = m_project->getViewFrame();


### PR DESCRIPTION
![image](https://github.com/opentoonz/iwawarper/assets/17974955/331581f2-ff92-4055-a43b-f2d2df26c245)
_Left: Every correnspondence points have the same weight. The shape is evenly deformed.
Right: Increase the weights at the four corners to 3 and leave the weight of the center shape to 1. The mesh is stretched to the left and right, creating an uneven distortion like that of a cylinder._

This PR will add a new parameter, `weight` to each correspondence point.
The higher the value of the `weight`, the more the mesh vertices are attracted.
In other words, where the `weight` parameters are large, the mesh is denser and the picture looks squeezed.
This allows you to represent a shape with gradually tilting surfaces, such as a cylinder, for example.

The `weight` value of the selected points can be adjusted in the tool options panel for the Correspondence tool.