### PR TITLE
Actions: change macos runner

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   macOS:
-    runs-on: macos-latest
+    runs-on: 	macos-13
     steps:
     - name: checkout with cached LFS
       uses: nschloe/action-cached-lfs-checkout@v1
@@ -39,7 +39,7 @@ jobs:
         mkdir build
         cd build
         cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQTDIR='/usr/local/opt/qt@5' -DWITH_TRANSLATION=OFF
-        ninja -w dupbuild=warn
+        ninja
     
     - name: Introduce Libraries and Stuff
       run: |


### PR DESCRIPTION
This PR changes macos runner from `macos-latest` to `macos-13` since the latest macos runner becomes using M1 processors and fails to build.
Also removed `-w dupbuild=warn` option from `ninja` command as it was removed last December.