### PR TITLE
Enable HighDPI display scaling

### DIFF
--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -23,6 +23,11 @@ FILE* Logger::file           = nullptr;
 
 int main(int argc, char* argv[]) {
   Logger::Initialize("Log.txt");
+
+  // Enables high-DPI scaling. This attribute must be set before QApplication is
+  // constructed. Available from Qt 5.6.
+  QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
   QApplication a(argc, argv);
   a.setApplicationName("IwaWarper");
   a.setApplicationVersion("1.0.1");


### PR DESCRIPTION
This PR adds `Qt::AA_EnableHighDpiScaling` option so that the UI is shown in suitable size when using a high dpi monitor. 