### PR TITLE
Prevent dialog from being positioned off-screen

### DIFF
--- a/sources/iwdialog.cpp
+++ b/sources/iwdialog.cpp
@@ -8,6 +8,8 @@
 
 #include <QVariant>
 #include <iostream>
+#include <QGuiApplication>
+#include <QScreen>
 
 //---------------------------------------------------
 // コンストラクタで、位置/サイズをロード
@@ -43,6 +45,13 @@ IwDialog::IwDialog(QWidget* parent, SettingsId dialogName, bool isResizable)
   // リサイズ不可なら移動だけ
   else {
     m_geom = QRect(leftEdge, topEdge, 1, 1);
+  }
+
+  // スクリーン画面外の場合は、プライマリスクリーンの中心に持ってくる
+  QScreen* screen = QGuiApplication::screenAt(mapToGlobal(m_geom.center()));
+  if (!screen) {
+    m_geom.moveCenter(mapFromGlobal(
+        QGuiApplication::primaryScreen()->virtualGeometry().center()));
   }
 }
 


### PR DESCRIPTION
This PR resolves the problem of dialogs moving off-screen and becoming invisible.
If the stored dialog location extends outside the current screen environment, the dialog will be moved to the center of the primary screen.