### PR TITLE
gha: switch macos runner to macos-15-intel

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   macOS:
-    runs-on: 	macos-13
+    runs-on: 	macos-15-intel
     steps:
     - name: checkout with cached LFS
       uses: nschloe/action-cached-lfs-checkout@v1

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Specify the minimum version of CMake 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 # Specify the project name
 project(IwaWarper VERSION 1.0.0)


### PR DESCRIPTION
The macOS 13 runner image will be retired by December 4th, 2025. 