### PR TITLE
Fix Bezier BBox Calculation

### DIFF
--- a/sources/iwtool.cpp
+++ b/sources/iwtool.cpp
@@ -256,6 +256,7 @@ void IwTool::drawJoinLine(ShapePair* shapePair) {
       shapePair->getDiscreteCorrValues(onePix, frame, 1);
 
   m_viewer->setLineStipple(2, 0xCCCC);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   // 各ベジエ座標を繋ぐ
   for (int d = 0; d < discreteCorrValues1.size(); d++) {

--- a/sources/sceneviewer.cpp
+++ b/sources/sceneviewer.cpp
@@ -484,6 +484,8 @@ void SceneViewer::renderText(double x, double y, const QString& str,
   m_p->setFont(font);
   m_p->drawText(x, this->height() - y, str);
   m_p->beginNativePainting();
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 }
 
 //----------------------------------

--- a/sources/shapepair.cpp
+++ b/sources/shapepair.cpp
@@ -53,6 +53,11 @@ const int LockPos     = 40;
 const int PinPos      = 70;
 const int CorrIndent  = 100;
 
+const double epsilon = 1e-8;
+inline bool areAlmostEqual(double A, double B, double err = epsilon) {
+  return std::abs(A - B) <= epsilon;
+}
+
 // ●直線を作る
 
 // verticePに、Start, Endをリニア補間した座標を格納していく
@@ -139,7 +144,7 @@ QRectF getBezierBBox(QPointF p0, QPointF p1, QPointF p2, QPointF p3) {
     valVec.push_back(v3);
 
     // 重解の場合
-    if (a == 0.0) {
+    if (areAlmostEqual(a, 0.0)) {
       double d = 2.0 * (v2 - 2.0 * v1 + v0);
       if (d != 0.0) {
         double t = -(v1 - v0) / d;


### PR DESCRIPTION
This PR fixes calculation of boundary of a bezier curve, considering errors of double.
This also fixes correspondence tool gadget's visualization.