### PR TITLE
Fix render bbox

### DIFF
--- a/sources/halfedge.cpp
+++ b/sources/halfedge.cpp
@@ -162,6 +162,17 @@ double HEFace::centroidDepth() const {
   return (A->from_pos.z() + B->from_pos.z() + C->from_pos.z()) / 3.0;
 }
 
+QRectF HEFace::getToBBox() const {
+  QVector3D Apos = halfedge->vertex->to_pos;
+  QVector3D Bpos = halfedge->next->vertex->to_pos;
+  QVector3D Cpos = halfedge->prev->vertex->to_pos;
+
+  return QRectF(QPointF(std::min(std::min(Apos.x(), Bpos.x()), Cpos.x()),
+                        std::min(std::min(Apos.y(), Bpos.y()), Cpos.y())),
+                QPointF(std::max(std::max(Apos.x(), Bpos.x()), Cpos.x()),
+                        std::max(std::max(Apos.y(), Bpos.y()), Cpos.y())));
+}
+
 //---------------------------------------------------
 
 // Find a pair half edge of he and register it
@@ -643,8 +654,8 @@ void HEModel::checkFaceVisibility(const QPolygonF& parentShapePolygon) {
     HEVertex* C            = he->prev->vertex;
     QVector3D fromCentroid = (A->from_pos + B->from_pos + C->from_pos) / 3.0;
     if (!parentShapePolygon.containsPoint(fromCentroid.toPointF(),
-                                         Qt::WindingFill))
-     face->isVisible = false;
+                                          Qt::WindingFill))
+      face->isVisible = false;
   }
 }
 
@@ -770,4 +781,17 @@ void HEModel::print() {
     i++;
   }
   std::cout << "------------" << std::endl << std::endl;
+}
+
+// Toメッシュ形状のBBoxを返す
+QRectF HEModel::getToBBox() {
+  QRectF retRect = QRectF();
+  // 全てのfacesについて
+  QList<HEFace*>::iterator itr;
+  for (itr = faces.begin(); itr != faces.end(); ++itr) {
+    if (!(*itr)->isVisible) continue;
+
+    retRect |= (*itr)->getToBBox();
+  }
+  return retRect;
 }

--- a/sources/halfedge.h
+++ b/sources/halfedge.h
@@ -112,6 +112,8 @@ public:
   bool hasConstantDepth() const;
   // 重心のDepthを返す
   double centroidDepth() const;
+  // BBoxを返す
+  QRectF getToBBox() const;
 };
 
 class HEModel {
@@ -179,6 +181,9 @@ public:
                         HEVertex* end);
 
   void print();
+
+  // Toメッシュ形状のBBoxを返す
+  QRectF getToBBox();
 };
 
 #endif

--- a/sources/iwrenderinstance.cpp
+++ b/sources/iwrenderinstance.cpp
@@ -400,9 +400,16 @@ TRaster64P IwRenderInstance::warpLayer(IwLayer* layer,
   // demultiplyする
   if (checkIsPremultiplied(inRas)) TRop::depremultiply(inRas);
 
+  // 計算範囲はメッシュのバウンディングボックス
+  QRectF faceBBox = model.getToBBox();
+  QRect boundingRect =
+      faceBBox.toRect()
+          .marginsAdded(QMargins(5, 5, 5, 5))
+          .intersected(QRect(QPoint(), m_project->getWorkAreaSize()));
+
   // ここで、Matteに指定したレイヤがある場合、マット画像を作成する
   // shapes.last()がこのグループの親シェイプ
-  TRasterGR8P matteRas = createMatteRas(shapes.last());
+  TRasterGR8P matteRas = createMatteRas(shapes.last(), boundingRect);
 
   // ここで、Morphological
   // Supersamplingを行う場合、サンプル用の境界線マップ画像を生成する
@@ -411,7 +418,7 @@ TRaster64P IwRenderInstance::warpLayer(IwLayer* layer,
   // ゆがんだ形状を描画する
   TRaster64P outRas = HEmapTrianglesToRaster_Multi(
       model, inRas, matteRas, mlssRefRas, shapes.last(), origin,
-      QPolygonF(parentShapeVerticesTo));
+      QPolygonF(parentShapeVerticesTo), boundingRect);
 
   return outRas;
 }
@@ -976,21 +983,11 @@ void ResampleResults_Worker::run() {
 TRaster64P IwRenderInstance::HEmapTrianglesToRaster_Multi(
     HEModel& model, TRaster64P srcRas, TRasterGR8P matteRas,
     TRaster64P mlssRefRas, ShapePair* shape, QPoint& origin,
-    const QPolygonF& parentShapePolygon) {
-  QSize workAreaSize = m_project->getWorkAreaSize();
-  // 計算範囲
-  QRectF shapeBBox = shape->getBBox(
-      m_frame, 1);  // TO のバウンディングボックス（IwaWarper座標系）
-  shapeBBox          = QRectF(shapeBBox.left() * (double)workAreaSize.width(),
-                              shapeBBox.top() * (double)workAreaSize.height(),
-                              shapeBBox.width() * (double)workAreaSize.width(),
-                              shapeBBox.height() * (double)workAreaSize.height());
-  QRect boundingRect = shapeBBox.toRect()
-                           .marginsAdded(QMargins(5, 5, 5, 5))
-                           .intersected(QRect(QPoint(), workAreaSize));
-
+    const QPolygonF& parentShapePolygon, const QRect& boundingRect) {
   // 画面外にTo形状がはみ出しているとき
   if (boundingRect.isEmpty()) return TRaster64P();
+
+  QSize workAreaSize = m_project->getWorkAreaSize();
 
   // 計算範囲の原点
   origin = boundingRect.topLeft();
@@ -1109,10 +1106,13 @@ TRaster64P IwRenderInstance::HEmapTrianglesToRaster_Multi(
 //---------------------------------------------------
 // マット画像を作成する
 //---------------------------------------------------
-TRasterGR8P IwRenderInstance::createMatteRas(ShapePair* shape) {
+TRasterGR8P IwRenderInstance::createMatteRas(ShapePair* shape,
+                                             const QRect& boundingRect) {
   ShapePair::MatteInfo matteInfo = shape->matteInfo();
   if (matteInfo.layerName.isEmpty()) return TRasterGR8P();
   if (matteInfo.colors.isEmpty()) return TRasterGR8P();
+  // 画面外にTo形状がはみ出しているとき
+  if (boundingRect.isEmpty()) return TRasterGR8P();
 
   IwLayer* matteLayer = m_project->getLayerByName(matteInfo.layerName);
   if (!matteLayer) return TRasterGR8P();
@@ -1122,19 +1122,6 @@ TRasterGR8P IwRenderInstance::createMatteRas(ShapePair* shape) {
 
   // 計算範囲
   QSize workAreaSize = m_project->getWorkAreaSize();
-  QRectF shapeBBox   = shape->getBBox(
-      m_frame, 1);  // TO のバウンディングボックス（IwaWarper座標系）
-  shapeBBox = QRectF(shapeBBox.left() * (double)workAreaSize.width(),
-                     shapeBBox.top() * (double)workAreaSize.height(),
-                     shapeBBox.width() * (double)workAreaSize.width(),
-                     shapeBBox.height() * (double)workAreaSize.height());
-
-  QRect boundingRect = shapeBBox.toRect()
-                           .marginsAdded(QMargins(5, 5, 5, 5))
-                           .intersected(QRect(QPoint(), workAreaSize));
-
-  // 画面外にTo形状がはみ出しているとき
-  if (boundingRect.isEmpty()) return TRasterGR8P();
 
   // サンプル点のためのオフセット
   QPointF sampleOffset(0.5f * (double)(ras->getLx() - workAreaSize.width()) +

--- a/sources/iwrenderinstance.h
+++ b/sources/iwrenderinstance.h
@@ -169,7 +169,8 @@ class IwRenderInstance : public QObject, public QRunnable {
                                           TRasterGR8P matteRas,
                                           TRaster64P mlssRefRas,
                                           ShapePair* shape, QPoint& origin,
-                                          const QPolygonF& parentShapePolygon);
+                                          const QPolygonF& parentShapePolygon,
+                                          const QRect& boundingRect);
 
   // 三角形の位置をキャッシュする
   void HEcacheTriangles(HEModel& model, ShapePair* shape,
@@ -177,7 +178,7 @@ class IwRenderInstance : public QObject, public QRunnable {
                         const QPolygonF& parentShapePolygon);
 
   // マット画像を作成する
-  TRasterGR8P createMatteRas(ShapePair* shape);
+  TRasterGR8P createMatteRas(ShapePair* shape, const QRect& boundingRect);
 
   // Morphological
   // Supersamplingを行う場合、サンプル用の境界線マップ画像を生成する


### PR DESCRIPTION
This PR changes the rendering calculation area from the parent shape's bounding box to the mesh's bounding box.
This is because, if a shape is bent, child shapes may extend beyond the parent shape's bounding box and form the mesh.